### PR TITLE
Added README.md to the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# mutxt
+
+`mutxt` is a small text editor inspired by [antirez's
+kilo](https://github.com/antirez/kilo), but written in Rust using the Termion
+library.
+
+## Installation
+
+To install `mutxt`, first install [Rust](https://rust-lang.org), then run the
+command
+
+```sh
+$ cargo install
+```
+
+in the directory you clone `mutxt` into.


### PR DESCRIPTION
README explains how to install `mutxt` from source.